### PR TITLE
make manifest generation deterministic

### DIFF
--- a/manifest/vendor_sorter.go
+++ b/manifest/vendor_sorter.go
@@ -1,0 +1,15 @@
+package manifest
+
+type vendorSorter []Vendor
+
+func (v vendorSorter) Len() int {
+	return len(v)
+}
+
+func (v vendorSorter) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v vendorSorter) Less(i, j int) bool {
+	return v[i].Path < v[j].Path
+}

--- a/manifest/write.go
+++ b/manifest/write.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"sort"
 
 	"gopkg.in/yaml.v2"
 )
@@ -13,6 +14,9 @@ func Write(file string, vendors *[]Vendor) error {
 
 	var bytes []byte
 	var err error
+
+	// sort vendors to fixate ordering in manifest file
+	sort.Sort(vendorSorter(*vendors))
 
 	// marshal by format type
 	switch format {


### PR DESCRIPTION
I deleted and regenerated the vendor dir and manifest (vendor/ and vendor.yml) in a repo and got a diff on the manifest despite that actually no dependencies had been updated.

The ordering of the dependencies in the manifest file is not reproducible over several runs.

This should fix the ordering and make the output stable.